### PR TITLE
Enable epel-release but disable it

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -16,6 +16,8 @@
 FROM quay.io/centos/centos:8
 
 RUN dnf update -y \
+  && dnf install -y epel-release dnf-plugins-core \
+  && dnf config-manager --set-disabled epel \
   && dnf install -y python3-pip \
   && dnf clean all \
   && rm -rf /var/cache/dnf


### PR DESCRIPTION
We want to make it easy for project to install epel dependencies,
however we do not enable by default. This means, that projects that need
EPEL, will actively have to enable it and deal with the support issues
as a result of it.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>