### PR TITLE
Enable power tools repo by default

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -18,6 +18,7 @@ FROM quay.io/centos/centos:8
 RUN dnf update -y \
   && dnf install -y epel-release dnf-plugins-core \
   && dnf config-manager --set-disabled epel \
+  && dnf config-manager --set-enabled powertools \
   && dnf install -y python38-pip \
   && dnf clean all \
   && rm -rf /var/cache/dnf


### PR DESCRIPTION
This repo is managed by centos team, but disable. Enabling it will allow
for more python38 packages to be installed.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>