### PR TITLE
Include glibc-langpack-en to fix locale warnings

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -16,7 +16,7 @@
 FROM quay.io/centos/centos:8
 
 RUN dnf update -y \
-  && dnf install -y epel-release dnf-plugins-core \
+  && dnf install -y epel-release dnf-plugins-core glibc-langpack-en \
   && dnf config-manager --set-disabled epel \
   && dnf config-manager --set-enabled powertools \
   && dnf module enable -y python38-devel \


### PR DESCRIPTION
Default to glibc-langpack-en to clean up locale warnings.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>