### PR TITLE
Clean up after ourself better

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -35,12 +35,16 @@ RUN if [[ "$CONTAINER_IMAGE" =~ "centos" ]] ; then \
     dnf module enable -y python38-devel ; \
     dnf clean all ; \
     rm -rf /var/cache/dnf ; \
+    rm -rf /var/lib/dnf/history.* ; \
+    rm -rf /var/log/* ; \
   fi
 
 RUN dnf update -y \
   && dnf install -y glibc-langpack-en python38-pip \
   && dnf clean all \
-  && rm -rf /var/cache/dnf
+  && rm -rf /var/cache/dnf \
+  && rm -rf /var/lib/dnf/history.* \
+  && rm -rf /var/log/*
 
 # NOTE(pabelanger): We do this to allow users to install python36 but not
 # change python3 to python36.
@@ -55,7 +59,9 @@ RUN dnf update -y \
   && pip3 install dumb-init --no-cache-dir -c constraints.txt \
   && dnf remove -y gcc \
   && dnf clean all \
-  && rm -rf /var/cache/dnf
+  && rm -rf /var/cache/dnf \
+  && rm -rf /var/lib/dnf/history.* \
+  && rm -rf /var/log/*
 
 WORKDIR /
 RUN rm -rf $REMOTE_SOURCE_DIR


### PR DESCRIPTION
As we run dnf commands, this like a history and logs file are generated.
In an effort to save disk space, start to delete these files too.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>